### PR TITLE
Apply trim to create user

### DIFF
--- a/src/lib/createUser.js
+++ b/src/lib/createUser.js
@@ -10,17 +10,27 @@ const trimAnswer = (answer) => {
   return answer.trim()
 }
 
+const validateAnswer = (errorMessage) => (answer) => {
+  if(!trimAnswer(answer)) {
+    return errorMessage
+  }
+
+  return !!answer
+}
+
 async function createUser(store) {
   const questions = [
     {
       type: "input",
       name: "name",
       message: "Enter your git user name",
+      validate: validateAnswer("Please specify the name of git"),
     },
     {
       type: "input",
       name: "email",
       message: "Enter your git user email",
+      validate: validateAnswer("Please specify the email ofgGit"),
     },
     {
       type: "input",

--- a/src/lib/createUser.js
+++ b/src/lib/createUser.js
@@ -2,6 +2,14 @@
 
 const { prompt } = require("inquirer");
 
+const trimAnswer = (answer) => {
+  if(typeof answer !== 'string') {
+    throw new Error('Answer must be a string')
+  }
+
+  return answer.trim()
+}
+
 async function createUser(store) {
   const questions = [
     {
@@ -26,9 +34,9 @@ async function createUser(store) {
   const users = store.get("users");
 
   const newUser = {
-    name: res.name,
-    email: res.email,
-    signingKey: res.signingKey || null,
+    name: trimAnswer(res.name),
+    email: trimAnswer(res.email),
+    signingKey: trimAnswer(res.signingKey) || null,
   };
 
   if (users.includes(newUser)) {

--- a/src/lib/createUser.js
+++ b/src/lib/createUser.js
@@ -24,18 +24,21 @@ async function createUser(store) {
       type: "input",
       name: "name",
       message: "Enter your git user name",
+      transformer: trimAnswer,
       validate: validateAnswer("Please specify the name of git"),
     },
     {
       type: "input",
       name: "email",
       message: "Enter your git user email",
+      transformer: trimAnswer,
       validate: validateAnswer("Please specify the email ofgGit"),
     },
     {
       type: "input",
       name: "signingKey",
       message: "(Optional) Enter your GPG signing key",
+      transformer: trimAnswer,
     },
   ];
 


### PR DESCRIPTION
In the [conf](https://github.com/sindresorhus/conf) used as a `store`, `string containing spaces` is recognized for the **different instance key**.

For example, the keys in the following strings are taken as different keys.

```js
const Conf = require('conf');

const config = new Conf();
config.set('unicorn', 'case 1');
config.set(' unicorn', 'case 2');
config.set('unicorn ', 'case 3');
config.set(' unicorn ', 'case 4');
```


Therefore,  **I think that all answers received from users should be trimmed.**


As well as, I think that it is necessary to prevent the case where `the user who uses git-user` accidentally enters a space.

However, if you think that need to set Local partially, I'll remove the 989222e commit.

